### PR TITLE
Make command ephemeral

### DIFF
--- a/commands/membre-proche.js
+++ b/commands/membre-proche.js
@@ -42,7 +42,7 @@ module.exports = {
 
   async execute(interaction) {
     try {
-      await interaction.deferReply();
+      await interaction.deferReply({ ephemeral: true });
 
       const memberLocationManager = require('../utils/memberLocationManager');
       const guildId = interaction.guildId;
@@ -106,14 +106,11 @@ module.exports = {
         }
         if (nearby.length > 10) lines.push(`… et ${nearby.length - 10} autres.`);
       }
-
       const content = lines.join('\n');
-
       if (attachment) {
         return interaction.editReply({ content, files: [attachment] });
-      } else {
-        return interaction.editReply(content);
       }
+      return interaction.editReply(content);
     } catch (error) {
       return interaction.editReply('Une erreur est survenue.');
     }


### PR DESCRIPTION
Make the `/membre-proche` command's replies ephemeral to ensure output is only visible to the invoker.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab2f954f-56f1-4e4d-a7d9-daf12b9f8cc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab2f954f-56f1-4e4d-a7d9-daf12b9f8cc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

