### PR TITLE
Implementer le dégradé de couleur pour le rôle

### DIFF
--- a/discord-role-colors/src/palette.js
+++ b/discord-role-colors/src/palette.js
@@ -1,15 +1,40 @@
-export const ROLE_STYLES = [
-  { key: 'licorne',     name: '🦄 Licorne Pastel',     color: '#F6A6FF' },
-  { key: 'arcenciel',   name: '🌈 Arc-en-ciel',        color: '#FF6EC7' },
-  { key: 'rose',        name: '🌸 Rose Sakura',        color: '#E91E63' },
-  { key: 'violet',      name: '🔮 Violet Améthyste',   color: '#9B59B6' },
-  { key: 'bleu',        name: '🌊 Bleu Océan',         color: '#3498DB' },
-  { key: 'turquoise',   name: '🧜‍♀️ Turquoise',       color: '#1ABC9C' },
-  { key: 'vert',        name: '🌿 Vert Forêt',         color: '#2ECC71' },
-  { key: 'or',          name: '👑 Or Royal',           color: '#F1C40F' },
-  { key: 'orange',      name: '🔥 Orange Néon',        color: '#FF9E00' },
-  { key: 'gris',        name: '🖤 Charbon Chic',       color: '#2C2F33' }
-];
+function hexToRgb(hex) {
+  const normalized = hex.replace('#', '');
+  const bigint = parseInt(normalized, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255
+  };
+}
+
+function rgbToHex(r, g, b) {
+  const toHex = n => n.toString(16).padStart(2, '0').toUpperCase();
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function generateGradient(startHex, endHex, steps) {
+  const start = hexToRgb(startHex);
+  const end = hexToRgb(endHex);
+  const gradient = [];
+  for (let i = 0; i < steps; i++) {
+    const t = steps === 1 ? 0 : i / (steps - 1);
+    const r = Math.round(start.r + (end.r - start.r) * t);
+    const g = Math.round(start.g + (end.g - start.g) * t);
+    const b = Math.round(start.b + (end.b - start.b) * t);
+    gradient.push(rgbToHex(r, g, b));
+  }
+  return gradient;
+}
+
+// Pastel gradient from lavender to pink (similar to screenshot)
+const GRADIENT_COLORS = generateGradient('#A78BFA', '#F9A8D4', 10);
+
+export const ROLE_STYLES = GRADIENT_COLORS.map((hex, index) => ({
+  key: `gradient-${String(index + 1).padStart(2, '0')}`,
+  name: `🦄 Dégradé ${String(index + 1).padStart(2, '0')}`,
+  color: hex
+}));
 
 export function buildChoicesForSlashCommand() {
   return ROLE_STYLES.map(style => ({ name: style.name, value: style.key }));

--- a/utils/rolePalette.js
+++ b/utils/rolePalette.js
@@ -1,15 +1,40 @@
-const ROLE_STYLES = [
-	{ key: 'licorne',   name: '🦄 Licorne Pastel',   color: '#F6A6FF' },
-	{ key: 'arcenciel', name: '🌈 Arc-en-ciel',      color: '#FF6EC7' },
-	{ key: 'rose',      name: '🌸 Rose Sakura',      color: '#E91E63' },
-	{ key: 'violet',    name: '🔮 Violet Améthyste', color: '#9B59B6' },
-	{ key: 'bleu',      name: '🌊 Bleu Océan',       color: '#3498DB' },
-	{ key: 'turquoise', name: '🧜‍♀️ Turquoise',     color: '#1ABC9C' },
-	{ key: 'vert',      name: '🌿 Vert Forêt',       color: '#2ECC71' },
-	{ key: 'or',        name: '👑 Or Royal',         color: '#F1C40F' },
-	{ key: 'orange',    name: '🔥 Orange Néon',      color: '#FF9E00' },
-	{ key: 'gris',      name: '🖤 Charbon Chic',     color: '#2C2F33' }
-];
+function hexToRgb(hex) {
+	const normalized = hex.replace('#', '');
+	const bigint = parseInt(normalized, 16);
+	return {
+		r: (bigint >> 16) & 255,
+		g: (bigint >> 8) & 255,
+		b: bigint & 255
+	};
+}
+
+function rgbToHex(r, g, b) {
+	const toHex = (n) => n.toString(16).padStart(2, '0').toUpperCase();
+	return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function generateGradient(startHex, endHex, steps) {
+	const start = hexToRgb(startHex);
+	const end = hexToRgb(endHex);
+	const gradient = [];
+	for (let i = 0; i < steps; i++) {
+		const t = steps === 1 ? 0 : i / (steps - 1);
+		const r = Math.round(start.r + (end.r - start.r) * t);
+		const g = Math.round(start.g + (end.g - start.g) * t);
+		const b = Math.round(start.b + (end.b - start.b) * t);
+		gradient.push(rgbToHex(r, g, b));
+	}
+	return gradient;
+}
+
+// Pastel gradient from lavender to pink (similar to screenshot)
+const GRADIENT_COLORS = generateGradient('#A78BFA', '#F9A8D4', 10);
+
+const ROLE_STYLES = GRADIENT_COLORS.map((hex, index) => ({
+	key: `gradient-${String(index + 1).padStart(2, '0')}`,
+	name: `🦄 Dégradé ${String(index + 1).padStart(2, '0')}`,
+	color: hex
+}));
 
 function buildChoicesForSlashCommand() {
 	return ROLE_STYLES.map(style => ({ name: style.name, value: style.key }));


### PR DESCRIPTION
Replaces the fixed role color palette with a 10-step pastel gradient for `/color-role` and `/setup-colors`.

This implements a gradient color system by generating multiple distinct role colors that transition from lavender to pink, simulating a gradient effect since Discord roles only support single colors.

---
<a href="https://cursor.com/background-agent?bcId=bc-8df187c4-e7bd-4f8b-87a3-b5dcb25c24ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8df187c4-e7bd-4f8b-87a3-b5dcb25c24ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

