### PR TITLE
Investigate config issues with personal nsfw prompts

### DIFF
--- a/handlers/MainRouterHandler.js
+++ b/handlers/MainRouterHandler.js
@@ -1512,6 +1512,21 @@ class MainRouterHandler {
             if (customId === 'aouv_nsfw_prompt_edit_select_truth') {
                 return await handler.handleAouvNsfwPromptEditSelect(interaction, 'verite');
             }
+            if (customId === 'aouv_nsfw_prompt_remove_select_action') {
+                return await handler.handleAouvNsfwPromptRemoveSelect(interaction, 'action');
+            }
+            if (customId === 'aouv_nsfw_prompt_remove_select_truth') {
+                return await handler.handleAouvNsfwPromptRemoveSelect(interaction, 'verite');
+            }
+            if (customId === 'aouv_nsfw_prompt_edit_kind_select') {
+                return await handler.handleAouvNsfwPromptEditKindSelect(interaction);
+            }
+            if (customId === 'aouv_nsfw_prompt_remove_kind_select') {
+                return await handler.handleAouvNsfwPromptRemoveKindSelect(interaction);
+            }
+            if (customId === 'aouv_nsfw_prompt_list_custom_kind_select') {
+                return await handler.handleAouvNsfwPromptListCustomKindSelect(interaction);
+            }
 
             // Gestion des modals d'édition
             if (customId === 'aouv_prompt_edit_modal') {
@@ -1591,6 +1606,24 @@ class MainRouterHandler {
                 const kind = parts[4]; // action ou verite
                 const page = parseInt(parts[6], 10);
                 return await handler.showAouvPromptOverrideBaseListPaged(interaction, kind, page);
+            }
+            if (customId.startsWith('aouv_nsfw_prompt_edit_list_') && customId.includes('_page_')) {
+                const parts = customId.split('_');
+                const kind = parts[5]; // action ou verite
+                const page = parseInt(parts[7], 10);
+                return await handler.showAouvNsfwPromptEditListPaged(interaction, kind, page);
+            }
+            if (customId.startsWith('aouv_nsfw_prompt_remove_list_') && customId.includes('_page_')) {
+                const parts = customId.split('_');
+                const kind = parts[5]; // action ou verite
+                const page = parseInt(parts[7], 10);
+                return await handler.showAouvNsfwPromptRemoveListPaged(interaction, kind, page);
+            }
+            if (customId.startsWith('aouv_nsfw_prompt_list_custom_') && customId.includes('_page_')) {
+                const parts = customId.split('_');
+                const kind = parts[5]; // action ou verite
+                const page = parseInt(parts[7], 10);
+                return await handler.showAouvNsfwPromptListCustomPaged(interaction, kind, page);
             }
 
             console.log(`⚠️ CustomId AouV non géré: ${customId}`);

--- a/index.render-final.js
+++ b/index.render-final.js
@@ -3033,6 +3033,28 @@ class RenderSolutionBot {
                     return;
                 }
 
+                // ==== AOUV NSFW — selects de type pour pagination ====
+                if (customId === 'aouv_nsfw_prompt_edit_kind_select') {
+                    const AouvConfigHandler = require('./handlers/AouvConfigHandler');
+                    const aouvHandler = new AouvConfigHandler(dataManager);
+                    await aouvHandler.handleAouvNsfwPromptEditKindSelect(interaction);
+                    return;
+                }
+
+                if (customId === 'aouv_nsfw_prompt_remove_kind_select') {
+                    const AouvConfigHandler = require('./handlers/AouvConfigHandler');
+                    const aouvHandler = new AouvConfigHandler(dataManager);
+                    await aouvHandler.handleAouvNsfwPromptRemoveKindSelect(interaction);
+                    return;
+                }
+
+                if (customId === 'aouv_nsfw_prompt_list_custom_kind_select') {
+                    const AouvConfigHandler = require('./handlers/AouvConfigHandler');
+                    const aouvHandler = new AouvConfigHandler(dataManager);
+                    await aouvHandler.handleAouvNsfwPromptListCustomKindSelect(interaction);
+                    return;
+                }
+
                 // ==== AOUV — selects sur listes paginées ====
                 if (customId === 'aouv_prompt_remove_select_action') {
                     const AouvConfigHandler = require('./handlers/AouvConfigHandler');
@@ -3059,6 +3081,20 @@ class RenderSolutionBot {
                     const AouvConfigHandler = require('./handlers/AouvConfigHandler');
                     const aouvHandler = new AouvConfigHandler(dataManager);
                     await aouvHandler.handleAouvPromptOverrideSelect(interaction, 'verite');
+                    return;
+                }
+
+                if (customId === 'aouv_nsfw_prompt_remove_select_action') {
+                    const AouvConfigHandler = require('./handlers/AouvConfigHandler');
+                    const aouvHandler = new AouvConfigHandler(dataManager);
+                    await aouvHandler.handleAouvNsfwPromptRemoveSelect(interaction, 'action');
+                    return;
+                }
+
+                if (customId === 'aouv_nsfw_prompt_remove_select_truth') {
+                    const AouvConfigHandler = require('./handlers/AouvConfigHandler');
+                    const aouvHandler = new AouvConfigHandler(dataManager);
+                    await aouvHandler.handleAouvNsfwPromptRemoveSelect(interaction, 'verite');
                     return;
                 }
 
@@ -3110,6 +3146,36 @@ class RenderSolutionBot {
                     const AouvConfigHandler = require('./handlers/AouvConfigHandler');
                     const aouvHandler = new AouvConfigHandler(dataManager);
                     await aouvHandler.showAouvPromptOverrideBaseListPaged(interaction, kind, page);
+                    return;
+                }
+
+                if (customId.startsWith('aouv_nsfw_prompt_edit_list_')) {
+                    const parts = String(customId || '').split('_');
+                    const kind = parts[parts.length - 3];
+                    const page = parseInt(parts[parts.length - 1], 10) || 1;
+                    const AouvConfigHandler = require('./handlers/AouvConfigHandler');
+                    const aouvHandler = new AouvConfigHandler(dataManager);
+                    await aouvHandler.showAouvNsfwPromptEditListPaged(interaction, kind, page);
+                    return;
+                }
+
+                if (customId.startsWith('aouv_nsfw_prompt_remove_list_')) {
+                    const parts = String(customId || '').split('_');
+                    const kind = parts[parts.length - 3];
+                    const page = parseInt(parts[parts.length - 1], 10) || 1;
+                    const AouvConfigHandler = require('./handlers/AouvConfigHandler');
+                    const aouvHandler = new AouvConfigHandler(dataManager);
+                    await aouvHandler.showAouvNsfwPromptRemoveListPaged(interaction, kind, page);
+                    return;
+                }
+
+                if (customId.startsWith('aouv_nsfw_prompt_list_custom_')) {
+                    const parts = String(customId || '').split('_');
+                    const kind = parts[parts.length - 3];
+                    const page = parseInt(parts[parts.length - 1], 10) || 1;
+                    const AouvConfigHandler = require('./handlers/AouvConfigHandler');
+                    const aouvHandler = new AouvConfigHandler(dataManager);
+                    await aouvHandler.showAouvNsfwPromptListCustomPaged(interaction, kind, page);
                     return;
                 }
 


### PR DESCRIPTION
Implement pagination and selection flows for NSFW custom prompts to enable listing, editing, and deleting them.

Previously, listing, editing, and deleting NSFW custom prompts in the AOUV config menu used simple modals without pagination or proper selectors, making these operations difficult or impossible with a large number of entries. This PR aligns the NSFW prompt management flow with the existing SFW flow, introducing type selection, paginated lists, and proper selection mechanisms for a consistent and functional user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-31993c8f-257c-466a-ae73-821f6a40cd90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-31993c8f-257c-466a-ae73-821f6a40cd90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

