### PR TITLE
Ajouter la suppression des messages au ban

### DIFF
--- a/COMMANDES_ADMIN.md
+++ b/COMMANDES_ADMIN.md
@@ -9,7 +9,7 @@
 - `/backup-status` (Administrateur): État du système de sauvegarde MongoDB
 
 - `/ban` (Administrateur): Bannir un membre
-  - Options: `membre` (User, requis), `raison` (String)
+  - Options: `membre` (User, requis), `suppr_jours` (Integer 0-7), `raison` (String)
 
 - Rappels de bump: automatiques, 2h après chaque bump DISBOARD détecté (pas de commande). Configurez le canal via la base de données si nécessaire.
 

--- a/commands/ban.js
+++ b/commands/ban.js
@@ -5,6 +5,13 @@ module.exports = {
     .setName('ban')
     .setDescription('Bannir un membre')
     .addUserOption(o => o.setName('membre').setDescription('Membre à bannir').setRequired(true))
+    .addIntegerOption(o =>
+      o
+        .setName('suppr_jours')
+        .setDescription('Supprimer les messages des N derniers jours (0-7)')
+        .setMinValue(0)
+        .setMaxValue(7)
+    )
     .addStringOption(o => o.setName('raison').setDescription('Raison'))
     .setDefaultMemberPermissions(PermissionFlagsBits.Administrator.toString()),
 
@@ -18,10 +25,12 @@ module.exports = {
     const guild = interaction.guild;
 
     const user = interaction.options.getUser('membre', true);
+    const deleteDays = interaction.options.getInteger('suppr_jours') ?? 0;
     const reason = interaction.options.getString('raison') || 'Aucun motif';
     const member = await guild.members.fetch(user.id).catch(() => null);
     if (!member) return interaction.reply({ content: 'Utilisateur introuvable dans ce serveur.', flags: 64 });
-    await member.ban({ reason });
+    const deleteMessageSeconds = Math.max(0, Math.min(7, deleteDays)) * 24 * 60 * 60;
+    await member.ban({ reason, deleteMessageSeconds });
     
     // Ajouter à l'historique global
     try {

--- a/docs/commands/README-Moderation.md
+++ b/docs/commands/README-Moderation.md
@@ -4,8 +4,8 @@ Permissions requises: Administrateur (sauf mention contraire). Les actions sont 
 
 Commandes:
 
-- `/ban membre:<User> raison:<String?>`
-  - Bannit un membre. Ajoute à l'historique, journalise l'action.
+- `/ban membre:<User> suppr_jours:<Int 0-7?> raison:<String?>`
+  - Bannit un membre. Optionnellement supprime ses messages des N derniers jours (0 à 7). Ajoute à l'historique, journalise l'action.
 - `/unban userid:<String> raison:<String?>`
   - Débannit par ID, log de l’événement si possible.
 - `/kick membre:<User> raison:<String?>`


### PR DESCRIPTION
Add `suppr_jours` option to `/ban` command to allow deleting messages up to 7 days.

---
<a href="https://cursor.com/background-agent?bcId=bc-120469e6-96ef-41fe-b297-a5c1b12dc50e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-120469e6-96ef-41fe-b297-a5c1b12dc50e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

