### PR TITLE
Corriger la création des rôles couleur

### DIFF
--- a/commands/color-role.js
+++ b/commands/color-role.js
@@ -116,10 +116,19 @@ module.exports = {
 
 				// Positionner le rôle créé le plus haut possible (juste sous le rôle le plus haut du bot)
 				try {
-					const meForPosition = interaction.guild.members.me;
+					let meForPosition = interaction.guild.members.me;
+					if (!meForPosition) {
+						try {
+							if (typeof interaction.guild.members.fetchMe === 'function') {
+								meForPosition = await interaction.guild.members.fetchMe();
+							} else {
+								meForPosition = await interaction.guild.members.fetch(interaction.client.user.id).catch(() => null);
+							}
+						} catch {}
+					}
 					if (meForPosition) {
 						const targetPosition = Math.max(1, meForPosition.roles.highest.position - 1);
-						await styleRole.setPosition(targetPosition);
+						await styleRole.setPosition(targetPosition, { reason: 'Positionner le rôle de couleur sous le rôle du bot (color-role)' });
 					}
 				} catch (e) {
 					console.warn('Impossible de positionner le rôle de couleur au plus haut:', e?.message);


### PR DESCRIPTION
Repositions color roles to appear directly under the bot's highest role and adds bulk reordering for `/setup-colors`.

The previous logic for positioning new color roles was placing them at the bottom of the role list. This change ensures new roles are immediately positioned correctly and introduces a robust reordering mechanism for all color roles after running `/setup-colors`, improving role hierarchy management. It also adds more resilient fetching of the bot's member object before attempting to set the role position.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf3d31fb-90e1-4c12-b851-287a9eec3521">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf3d31fb-90e1-4c12-b851-287a9eec3521">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

