### PR TITLE
Fix quarantine verification system

### DIFF
--- a/handlers/CommandHandler.js
+++ b/handlers/CommandHandler.js
@@ -84,7 +84,7 @@ class CommandHandler {
 
                 try {
                     await this.handleCooldown(interaction, command);
-                    const needsClient = ['bump', 'bump-config', 'config-bump'].includes(interaction.commandName);
+                    const needsClient = ['bump', 'bump-config', 'config-bump', 'quarantaine', 'test-verif'].includes(interaction.commandName);
                     if (needsClient) {
                         await command.execute(interaction, this.client);
                     } else {


### PR DESCRIPTION
Include `quarantaine` and `test-verif` commands to receive the full client instance.

This resolves the "bot.quarantineMember is not a function" error by ensuring these commands have access to client-bound methods. Previously, they only received the `dataManager` object.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a4dc8ba-6f47-49a1-87c2-e458df5c32af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a4dc8ba-6f47-49a1-87c2-e458df5c32af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

