### PR TITLE
Fix quarantine and admin notification menus

### DIFF
--- a/handlers/MainRouterHandler.js
+++ b/handlers/MainRouterHandler.js
@@ -936,6 +936,50 @@ class MainRouterHandler {
                 }
             }
 
+            // Sélecteur de rôle: rôle de quarantaine
+            if (customId === 'config_verif_quarantine_role') {
+                if (this.securityConfigHandler) {
+                    await this.securityConfigHandler.handleQuarantineRoleSelect(interaction);
+                    return true;
+                } else {
+                    await interaction.reply({ content: '❌ Module sécurité indisponible.', ephemeral: true });
+                    return true;
+                }
+            }
+
+            // Sélecteur de rôle: rôle vérifié
+            if (customId === 'config_verif_verified_role') {
+                if (this.securityConfigHandler) {
+                    await this.securityConfigHandler.handleVerifiedRoleSelect(interaction);
+                    return true;
+                } else {
+                    await interaction.reply({ content: '❌ Module sécurité indisponible.', ephemeral: true });
+                    return true;
+                }
+            }
+
+            // Sélecteur de canal: canal d'alertes
+            if (customId === 'config_verif_alert_channel') {
+                if (this.securityConfigHandler) {
+                    await this.securityConfigHandler.handleAlertChannelSelect(interaction);
+                    return true;
+                } else {
+                    await interaction.reply({ content: '❌ Module sécurité indisponible.', ephemeral: true });
+                    return true;
+                }
+            }
+
+            // Sélecteur de rôle: rôle modérateur pour mentions
+            if (customId === 'config_verif_moderator_role') {
+                if (this.securityConfigHandler) {
+                    await this.securityConfigHandler.handleModeratorRoleSelect(interaction);
+                    return true;
+                } else {
+                    await interaction.reply({ content: '❌ Module sécurité indisponible.', ephemeral: true });
+                    return true;
+                }
+            }
+
             return false;
         } catch (error) {
             console.error('❌ Erreur select menu interaction:', error);

--- a/managers/ModerationManager.js
+++ b/managers/ModerationManager.js
@@ -1118,6 +1118,22 @@ class ModerationManager {
     }
   }
 
+  /**
+   * Réinitialiser complètement la configuration de sécurité d'un serveur
+   * @param {string} guildId
+   */
+  async resetSecurityConfig(guildId) {
+    try {
+      const config = await this.dataManager.getData("security_config");
+      config[guildId] = this.getDefaultSecurityConfig(guildId);
+      await this.dataManager.saveData("security_config", config);
+      return config[guildId];
+    } catch (error) {
+      console.error('Erreur resetSecurityConfig:', error);
+      throw error;
+    }
+  }
+
   deepMerge(target, source) {
     const result = { ...target };
     for (const key in source) {


### PR DESCRIPTION
Adds configuration options for quarantine and admin notification settings in `/config-verif-menu`.

Previously, users could not set the quarantine role, verified role, alert channel, or moderator role through the `/config-verif-menu`, making these sections non-functional for configuration. This PR introduces the necessary select menus and handlers to enable this functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5efa109-331d-4cc2-aeff-da1653e41603">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5efa109-331d-4cc2-aeff-da1653e41603">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

