### PR TITLE
Prevent quarantined member channel access

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ const ReminderInteractionHandler = require('./handlers/ReminderInteractionHandle
 const ModerationManager = require('./managers/ModerationManager');
 const MusicManagerRouter = require('./managers/MusicManager');
 const SecurityButtonHandler = require('./handlers/SecurityButtonHandler');
+const ChannelCreateHandler = require('./handlers/ChannelCreateHandler');
 
 class BagBotRender {
     constructor() {
@@ -87,6 +88,7 @@ class BagBotRender {
         const LogManager = require('./managers/LogManager');
         this.logManager = new LogManager(this.dataManager, this.client);
         this.securityButtonHandler = new SecurityButtonHandler(this.moderationManager);
+        this.channelCreateHandler = new ChannelCreateHandler(this.moderationManager);
         // Optionnel: conserver config-bump uniquement pour UI? On va retirer bump complet; pas d'UI bump.
         this.mainRouterHandler = new MainRouterHandler(this.dataManager);
         this.commandHandler = new CommandHandler(this.client, this.dataManager);
@@ -953,7 +955,11 @@ class BagBotRender {
         });
 
         // Logs channels create/delete/update
-		this.client.on('channelCreate', async (channel) => { try { await this.logManager.logChannelCreate(channel); } catch {} });
+		this.client.on('channelCreate', async (channel) => {
+			try { await this.logManager.logChannelCreate(channel); } catch {}
+			// Appliquer immédiatement les restrictions de quarantaine sur les nouveaux canaux
+			try { if (this.channelCreateHandler) await this.channelCreateHandler.handleChannelCreate(channel); } catch {}
+		});
 		this.client.on('channelDelete', async (channel) => { try { await this.logManager.logChannelDelete(channel); } catch {} });
 		this.client.on('channelUpdate', async (oldChannel, newChannel) => { try { await this.logManager.logChannelUpdate(oldChannel, newChannel); } catch {} });
 


### PR DESCRIPTION
Enforce strict channel isolation for members in quarantine.

Previously, members with existing roles could still view other channels while in quarantine. This change integrates with a centralized quarantine system to deny access to all non-quarantine channels and automatically applies these restrictions to newly created channels.

---
<a href="https://cursor.com/background-agent?bcId=bc-a466850d-1552-4ffa-8af5-7de735564b7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a466850d-1552-4ffa-8af5-7de735564b7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

