### PR TITLE
Modifier la méthode de mise en quarantaine des membres

### DIFF
--- a/handlers/QuarantineChannelManager.js
+++ b/handlers/QuarantineChannelManager.js
@@ -51,7 +51,7 @@ class QuarantineChannelManager {
           },
           {
             id: quarantineRoleId,
-            allow: [PermissionFlagsBits.ViewChannel]
+            deny: [PermissionFlagsBits.ViewChannel]
           },
           // Permissions pour les modérateurs
           ...this.getModeratorPermissions(member.guild, config)
@@ -79,7 +79,7 @@ class QuarantineChannelManager {
           },
           {
             id: quarantineRoleId,
-            allow: [PermissionFlagsBits.ViewChannel]
+            deny: [PermissionFlagsBits.ViewChannel]
           },
           // Permissions pour les modérateurs
           ...this.getModeratorPermissions(member.guild, config)
@@ -427,8 +427,6 @@ class QuarantineChannelManager {
       const guild = member.guild;
       const channels = guild.channels.cache.filter(channel => {
         if (excludeChannelIds.includes(channel.id)) return false;
-        if (quarantineCategory && channel.parentId === quarantineCategory.id) return false;
-        if (channel.name?.toLowerCase?.().includes('quarantaine')) return false;
         return [
           ChannelType.GuildText,
           ChannelType.GuildVoice,

--- a/index.js
+++ b/index.js
@@ -1454,9 +1454,9 @@ class BagBotRender {
         const guild = member.guild;
 
         try {
-            // Supprimer l'accès à TOUS les autres canaux du serveur
+            // Supprimer l'accès à TOUS les autres canaux du serveur (sauf ceux créés pour la quarantaine)
             const allChannels = guild.channels.cache.filter(ch => 
-                ch.id !== textChannel.id && ch.id !== voiceChannel.id && ch.parentId !== textChannel.parentId
+                ch.id !== textChannel.id && ch.id !== voiceChannel.id
             );
 
             // Traitement par lots pour éviter les rate limits


### PR DESCRIPTION
Strictly limit quarantined members' access to only their designated text and voice channels.

The previous implementation allowed quarantined members to view other channels within the quarantine category or channels named 'quarantaine'. This change ensures that members can *only* see and access the two specific text and voice channels created for their quarantine, by applying explicit denials on all other channels and refining role permissions.

---
<a href="https://cursor.com/background-agent?bcId=bc-63b4c3d1-2de5-4230-af17-258576135d75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63b4c3d1-2de5-4230-af17-258576135d75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

