### PR TITLE
Manage quarantine and auto-verification

### DIFF
--- a/handlers/SecurityButtonHandler.js
+++ b/handlers/SecurityButtonHandler.js
@@ -73,23 +73,8 @@ class SecurityButtonHandler {
       if (typeof interaction.client.grantAccess === 'function') {
         await interaction.client.grantAccess(member, reason);
       } else {
-        const config = await this.moderationManager.getSecurityConfig(interaction.guild.id);
-        
-        // Retirer le rôle de quarantaine
-        if (config.accessControl?.quarantineRoleId) {
-          const quarantineRole = interaction.guild.roles.cache.get(config.accessControl.quarantineRoleId);
-          if (quarantineRole && member.roles.cache.has(quarantineRole.id)) {
-            await member.roles.remove(quarantineRole, reason);
-          }
-        }
-
-        // Ajouter le rôle vérifié
-        if (config.accessControl?.verifiedRoleId) {
-          const verifiedRole = interaction.guild.roles.cache.get(config.accessControl.verifiedRoleId);
-          if (verifiedRole) {
-            await member.roles.add(verifiedRole, reason);
-          }
-        }
+        const qManager = new QuarantineChannelManager(this.moderationManager);
+        await qManager.releaseFromQuarantine(member, reason);
       }
 
       // Notifier le membre


### PR DESCRIPTION
Automatically delete quarantine channels upon member release/kick/ban and fix auto-verification for new members.

Quarantine channels are now persisted, ensuring their deletion even if the bot restarts. Auto-verification was not consistently triggered on member join and is now correctly wired.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a6fe4cf-89ad-4c09-9227-908448366b2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a6fe4cf-89ad-4c09-9227-908448366b2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

