### PR TITLE
Fix confession config sub-menu in development

### DIFF
--- a/handlers/ConfessionConfigHandler.js
+++ b/handlers/ConfessionConfigHandler.js
@@ -3,10 +3,12 @@
  */
 
 const { EmbedBuilder, ChannelSelectMenuBuilder, ActionRowBuilder, StringSelectMenuBuilder, RoleSelectMenuBuilder } = require('discord.js');
+const ConfessionHandler = require('./ConfessionHandler');
 
 class ConfessionConfigHandler {
     constructor(dataManager) {
         this.dataManager = dataManager;
+        this.confessionHandler = new ConfessionHandler(dataManager);
     }
 
     async showMainConfigMenu(interaction) {
@@ -136,39 +138,13 @@ class ConfessionConfigHandler {
     }
 
     async showAdminLogsConfig(interaction) {
-        const embed = new EmbedBuilder()
-            .setColor('#3498db')
-            .setTitle('📊 Configuration Logs Admin')
-            .setDescription('Configuration des logs administrateur')
-            .addFields([{ name: '🚧 En développement', value: 'Cette section sera bientôt disponible', inline: false }]);
-
-        const selectMenu = new StringSelectMenuBuilder()
-            .setCustomId('confession_logs_back')
-            .setPlaceholder('Actions...')
-            .addOptions([
-                { label: '🔄 Retour Menu Principal', value: 'back_main', description: 'Retour au menu principal' }
-            ]);
-
-        const row = new ActionRowBuilder().addComponents(selectMenu);
-        await interaction.update({ embeds: [embed], components: [row] });
+        // Déléguer au handler complet des confessions
+        return await this.confessionHandler.handleLogsConfig(interaction);
     }
 
     async showAutoThreadConfig(interaction) {
-        const embed = new EmbedBuilder()
-            .setColor('#9b59b6')
-            .setTitle('🧵 Auto-Thread Confessions')
-            .setDescription('Configuration threads automatiques')
-            .addFields([{ name: '🚧 En développement', value: 'Cette section sera bientôt disponible', inline: false }]);
-
-        const selectMenu = new StringSelectMenuBuilder()
-            .setCustomId('confession_autothread_back')
-            .setPlaceholder('Actions...')
-            .addOptions([
-                { label: '🔄 Retour Menu Principal', value: 'back_main', description: 'Retour au menu principal' }
-            ]);
-
-        const row = new ActionRowBuilder().addComponents(selectMenu);
-        await interaction.update({ embeds: [embed], components: [row] });
+        // Déléguer au handler complet des confessions
+        return await this.confessionHandler.handleAutoThreadConfig(interaction);
     }
 
     // Méthodes d'alias pour compatibility


### PR DESCRIPTION
Enable 'Logs Admin' and 'Auto-Thread' submenus in confession configuration.

These submenus previously displayed 'En développement' and now delegate to existing, functional views in `ConfessionHandler.js`.

---
<a href="https://cursor.com/background-agent?bcId=bc-82183976-bbf5-473f-91d4-63013830bc93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82183976-bbf5-473f-91d4-63013830bc93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

