### PR TITLE
Add lavalink servers for stable music playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ LAVALINK_NODES=[
 ]
 ```
 
+- Options avancées de stabilité:
+```env
+# Ajouter les nœuds publics en plus de vos nœuds (SSL et non-SSL)
+LAVALINK_APPEND_PUBLIC=true
+# Mélanger l’ordre des nœuds au démarrage (répartition des connexions)
+LAVALINK_SHUFFLE_NODES=true
+# Désactiver totalement les nœuds publics (si vous avez vos propres nœuds)
+LAVALINK_DISABLE_PUBLIC=false
+```
+
+Exemple (nœuds multiples + ajout des publics):
+```env
+LAVALINK_NODES=[
+  {"name":"self-ssl","url":"lavalink.my-domain.com:443","auth":"my-secret","secure":true},
+  {"name":"self-nonssl","url":"10.0.0.12:2333","auth":"my-secret","secure":false}
+]
+LAVALINK_APPEND_PUBLIC=true
+LAVALINK_SHUFFLE_NODES=true
+```
+
 Le routeur `managers/MusicManager` utilise uniquement Lavalink. Commandes: `/play`, `/pause`, `/skip`, `/stop`, `/queue`, `/volume`, `/nowplaying`.
 
 Exemple (nœud public sécurisé):


### PR DESCRIPTION
Add more public Lavalink nodes (SSL/non-SSL) and options to append, shuffle, or disable them for improved music playback stability.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e9c1b52-5b98-48cb-aa7d-d7e6205abdd9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e9c1b52-5b98-48cb-aa7d-d7e6205abdd9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

