### PR TITLE
Fix dashboard logic

### DIFF
--- a/index.render-final.js
+++ b/index.render-final.js
@@ -502,6 +502,17 @@ class RenderSolutionBot {
             }
         }));
 
+        // Alias pour servir le JSON des catégories du dashboard à la racine également
+        app.get('/commands.json', (req, res) => {
+            res.sendFile(path.join(__dirname, 'public', 'dashboard', 'commands.json'));
+        });
+
+        // Fallback SPA pour les routes client (/dashboard/*, /docs/*)
+        app.get(['/dashboard/*', '/docs/*'], (req, res) => {
+            res.set('Cache-Control', 'no-store, must-revalidate');
+            res.sendFile(path.join(__dirname, 'public', 'dashboard', 'index.html'));
+        });
+
         // === Dashboard API désactivée temporairement ===
         app.get('/api/dashboard/overview', (req, res) => {
             res.status(503).json({ error: 'dashboard_disabled' });


### PR DESCRIPTION
Add SPA fallback for `/dashboard/*` and `/docs/*` routes and an alias for `/commands.json` to restore dashboard functionality and client-side routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6a5c97f-aff5-4426-b474-834d904563a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6a5c97f-aff5-4426-b474-834d904563a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

