### PR TITLE
Style map config for development

### DIFF
--- a/utils/modalHandler.js
+++ b/utils/modalHandler.js
@@ -27,6 +27,8 @@ class ModalHandler {
             'multiplier_modal',
             'add_role_reward_modal',
             'level_for_role',
+            'style_backgrounds_modal',
+            'style_backgrounds_default_modal',
             // Modals AOUV
             'aouv_prompt_add_modal',
             'aouv_prompt_add_bulk_modal',


### PR DESCRIPTION
Enable card style configuration by whitelisting related modals to remove 'in development' flag.

The "Images par style & rôle" feature in "Config Level" was incorrectly displaying an "in development" message upon submission because its associated modals (`style_backgrounds_modal` and `style_backgrounds_default_modal`) were not included in the `implementedModals` list. This PR adds them to resolve the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-97e9c2b7-2ada-414e-8c42-3c07017aa2a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97e9c2b7-2ada-414e-8c42-3c07017aa2a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

