### PR TITLE
Ajouter des réductions de cooldown à la boutique

### DIFF
--- a/commands/boutique.js
+++ b/commands/boutique.js
@@ -16,17 +16,19 @@ module.exports = {
 			const karmaDiscountsData = await dataManager.loadData('karma_discounts', {});
 			const allShopItems = shopData[guildId] || [];
 
-			// Catégorisation par catégorie logique
-			const isCustom = (t) => t === 'custom_object' || t === 'custom' || t === 'text' || !t;
-			const isTempRole = (t) => t === 'temporary_role' || t === 'temp_role';
-			const isPermRole = (t) => t === 'permanent_role' || t === 'perm_role';
-			const isSuite = (t) => t === 'private_24h' || t === 'private_monthly' || t === 'private_permanent';
-			const deriveCategoryFromType = (t) => {
-				if (isSuite(t)) return 'Suites privées';
-				if (isTempRole(t) || isPermRole(t)) return 'Rôles';
-				if (isCustom(t)) return 'Objets personnalisés';
-				return 'Autres';
-			};
+			            // Catégorisation par catégorie logique
+            const isCustom = (t) => t === 'custom_object' || t === 'custom' || t === 'text' || !t;
+            const isTempRole = (t) => t === 'temporary_role' || t === 'temp_role';
+            const isPermRole = (t) => t === 'permanent_role' || t === 'perm_role';
+            const isSuite = (t) => t === 'private_24h' || t === 'private_monthly' || t === 'private_permanent';
+            const isCooldownReduction = (t) => t === 'cooldown_reduction';
+            const deriveCategoryFromType = (t) => {
+                if (isSuite(t)) return 'Suites privées';
+                if (isTempRole(t) || isPermRole(t)) return 'Rôles';
+                if (isCooldownReduction(t)) return 'Réductions de Cooldown';
+                if (isCustom(t)) return 'Objets personnalisés';
+                return 'Autres';
+            };
 			
 			const categoriesMap = allShopItems.reduce((acc, item) => {
 				const raw = typeof item.category === 'string' ? item.category.trim() : '';
@@ -70,28 +72,39 @@ module.exports = {
 				.setDescription(descriptionText)
 				.setFooter({ text: 'Choisissez un article dans la catégorie souhaitée' });
 
-			const renderLine = (item) => {
-				let typeIcon = '🏆';
-				let typeText = 'Objet virtuel';
-				if (isTempRole(item.type)) {
-					typeIcon = '⌛';
-					typeText = `Rôle temporaire (${item.duration}j)`;
-				} else if (isPermRole(item.type)) {
-					typeIcon = '⭐';
-					typeText = 'Rôle permanent';
-				} else if (isCustom(item.type)) {
-					typeIcon = '🎨';
-					typeText = 'Objet personnalisé';
-				} else if (item.type === 'private_24h') {
-					typeIcon = '🔒';
-					typeText = 'Suite privée 24h (texte NSFW + vocal)';
-				} else if (item.type === 'private_monthly') {
-					typeIcon = '🗓️';
-					typeText = 'Suite privée 30j (texte NSFW + vocal)';
-				} else if (item.type === 'private_permanent') {
-					typeIcon = '♾️';
-					typeText = 'Suite privée permanente (texte NSFW + vocal)';
-				}
+			            const renderLine = (item) => {
+                let typeIcon = '🏆';
+                let typeText = 'Objet virtuel';
+                if (isTempRole(item.type)) {
+                    typeIcon = '⌛';
+                    typeText = `Rôle temporaire (${item.duration}j)`;
+                } else if (isPermRole(item.type)) {
+                    typeIcon = '⭐';
+                    typeText = 'Rôle permanent';
+                } else if (isCooldownReduction(item.type)) {
+                    if (item.reductionPercent === 100) {
+                        typeIcon = '🚀';
+                        typeText = `Actions illimitées (${item.durationDays}j)`;
+                    } else if (item.reductionPercent === 75) {
+                        typeIcon = '⚡';
+                        typeText = `Réduction 75% cooldowns (${item.durationDays}j)`;
+                    } else {
+                        typeIcon = '🔥';
+                        typeText = `Réduction 50% cooldowns (${item.durationDays}j)`;
+                    }
+                } else if (isCustom(item.type)) {
+                    typeIcon = '🎨';
+                    typeText = 'Objet personnalisé';
+                } else if (item.type === 'private_24h') {
+                    typeIcon = '🔒';
+                    typeText = 'Suite privée 24h (texte NSFW + vocal)';
+                } else if (item.type === 'private_monthly') {
+                    typeIcon = '🗓️';
+                    typeText = 'Suite privée 30j (texte NSFW + vocal)';
+                } else if (item.type === 'private_permanent') {
+                    typeIcon = '♾️';
+                    typeText = 'Suite privée permanente (texte NSFW + vocal)';
+                }
 				let priceText = `${item.price}💋`;
 				if (karmaDiscountPercent > 0) {
 					const discountedPrice = Math.floor(item.price * (100 - karmaDiscountPercent) / 100);

--- a/commands/voler.js
+++ b/commands/voler.js
@@ -55,13 +55,24 @@ module.exports = {
             const userData = await dataManager.getUser(userId, guildId);
             const targetData = await dataManager.getUser(target.id, guildId);
             
-            const now = Date.now();
-            const cooldownTime = cooldown;
+            // Calculer le cooldown avec réductions actives
+            const { calculateReducedCooldown, formatCooldownBuffMessage, cleanExpiredBuffs } = require('../utils/cooldownCalculator');
             
-            if (userData.lastSteal && (now - userData.lastSteal) < cooldownTime) {
-                const remaining = Math.ceil((cooldownTime - (now - userData.lastSteal)) / 60000);
+            // Nettoyer les buffs expirés
+            const buffsRemoved = cleanExpiredBuffs(userData);
+            if (buffsRemoved) {
+                await dataManager.updateUser(userId, guildId, userData);
+            }
+            
+            const now = Date.now();
+            const baseCooldownTime = cooldown;
+            const finalCooldownTime = calculateReducedCooldown(userData, baseCooldownTime);
+            
+            if (userData.lastSteal && (now - userData.lastSteal) < finalCooldownTime) {
+                const remaining = Math.ceil((finalCooldownTime - (now - userData.lastSteal)) / 60000);
+                const buffMessage = formatCooldownBuffMessage(userData);
                 return await interaction.reply({
-                    content: `⏰ Vous devez attendre encore **${remaining} minutes** avant de pouvoir voler à nouveau.`,
+                    content: `⏰ Vous devez attendre encore **${remaining} minutes** avant de pouvoir voler à nouveau.${buffMessage}`,
                     flags: 64
                 });
             }

--- a/handlers/EconomyConfigHandler.js
+++ b/handlers/EconomyConfigHandler.js
@@ -251,6 +251,7 @@ class EconomyConfigHandler {
                 { label: '🎨 Objets Personnalisés', value: 'objets', description: 'Créer des objets uniques' },
                 { label: '⌛ Rôles Temporaires', value: 'roles_temp', description: 'Rôles avec durée limitée' },
                 { label: '⭐ Rôles Permanents', value: 'roles_perm', description: 'Rôles définitifs' },
+                { label: '⚡ Réductions Cooldown', value: 'cooldown_reductions', description: 'Accélérer les actions du serveur' },
                 { label: '💸 Remises Karma', value: 'remises', description: 'Réductions basées sur karma' },
                 { label: '🔧 Modifier Objets Existants', value: 'manage_objets', description: 'Gérer objets créés' },
                 { label: '🗑️ Supprimer Articles', value: 'delete_articles', description: 'Supprimer objets/rôles' },
@@ -274,6 +275,8 @@ class EconomyConfigHandler {
             await this.showRolesTempMenu(interaction);
         } else if (value === 'roles_perm') {
             await this.showRolesPermMenu(interaction);
+        } else if (value === 'cooldown_reductions') {
+            await this.showCooldownReductionsMenu(interaction);
         } else if (value === 'remises') {
             await this.showRemisesMenu(interaction);
         } else if (value === 'manage_objets') {
@@ -343,6 +346,207 @@ class EconomyConfigHandler {
 
         const row = new ActionRowBuilder().addComponents(roleSelect);
         await interaction.update({ embeds: [embed], components: [row] });
+    }
+
+    async showCooldownReductionsMenu(interaction) {
+        const embed = new EmbedBuilder()
+            .setColor('#e74c3c')
+            .setTitle('⚡ Réductions de Cooldown')
+            .setDescription('Choisissez le type de réduction à ajouter à la boutique :')
+            .addFields([
+                {
+                    name: '📦 Articles disponibles',
+                    value: 
+                        '**🔥 50% de réduction :**\n' +
+                        '• 1 jour - Accélère toutes les actions de 50% pendant 24h\n' +
+                        '• 1 semaine - Accélère toutes les actions de 50% pendant 7 jours\n' +
+                        '• 1 mois - Accélère toutes les actions de 50% pendant 30 jours\n\n' +
+                        '**⚡ 75% de réduction :**\n' +
+                        '• 1 jour - Accélère toutes les actions de 75% pendant 24h\n' +
+                        '• 1 semaine - Accélère toutes les actions de 75% pendant 7 jours\n' +
+                        '• 1 mois - Accélère toutes les actions de 75% pendant 30 jours\n\n' +
+                        '**🚀 Actions illimitées :**\n' +
+                        '• 1 jour - Supprime tous les cooldowns pendant 24h\n' +
+                        '• 1 semaine - Supprime tous les cooldowns pendant 7 jours\n' +
+                        '• 1 mois - Supprime tous les cooldowns pendant 30 jours',
+                    inline: false
+                }
+            ]);
+
+        const selectMenu = new StringSelectMenuBuilder()
+            .setCustomId('cooldown_reduction_select')
+            .setPlaceholder('Choisissez un type de réduction...')
+            .addOptions([
+                { label: '🔥 50% - 1 jour', value: 'cd_50_1d', description: 'Réduction 50% pendant 24h' },
+                { label: '🔥 50% - 1 semaine', value: 'cd_50_1w', description: 'Réduction 50% pendant 7 jours' },
+                { label: '🔥 50% - 1 mois', value: 'cd_50_1m', description: 'Réduction 50% pendant 30 jours' },
+                { label: '⚡ 75% - 1 jour', value: 'cd_75_1d', description: 'Réduction 75% pendant 24h' },
+                { label: '⚡ 75% - 1 semaine', value: 'cd_75_1w', description: 'Réduction 75% pendant 7 jours' },
+                { label: '⚡ 75% - 1 mois', value: 'cd_75_1m', description: 'Réduction 75% pendant 30 jours' },
+                { label: '🚀 Illimité - 1 jour', value: 'cd_100_1d', description: 'Suppression totale pendant 24h' },
+                { label: '🚀 Illimité - 1 semaine', value: 'cd_100_1w', description: 'Suppression totale pendant 7 jours' },
+                { label: '🚀 Illimité - 1 mois', value: 'cd_100_1m', description: 'Suppression totale pendant 30 jours' },
+                { label: '🔙 Retour Boutique', value: 'back_boutique', description: 'Retour au menu boutique' }
+            ]);
+
+        const row = new ActionRowBuilder().addComponents(selectMenu);
+        await interaction.update({ embeds: [embed], components: [row] });
+    }
+
+    async handleCooldownReductionSelect(interaction) {
+        const value = interaction.values[0];
+        
+        if (value === 'back_boutique') {
+            return await this.showBoutiqueMenu(interaction);
+        }
+
+        // Parser la valeur (ex: cd_50_1d = 50% reduction for 1 day)
+        const [, reduction, duration] = value.split('_');
+        await this.showCooldownReductionConfigModal(interaction, reduction, duration);
+    }
+
+    async showCooldownReductionConfigModal(interaction, reduction, duration) {
+        // Mapper les valeurs pour un affichage compréhensible
+        const reductionMap = {
+            '50': { name: '🔥 50% de réduction', percent: 50 },
+            '75': { name: '⚡ 75% de réduction', percent: 75 },
+            '100': { name: '🚀 Actions illimitées', percent: 100 }
+        };
+        
+        const durationMap = {
+            '1d': { name: '1 jour', days: 1 },
+            '1w': { name: '1 semaine', days: 7 },
+            '1m': { name: '1 mois', days: 30 }
+        };
+
+        const reductionInfo = reductionMap[reduction];
+        const durationInfo = durationMap[duration];
+        
+        const itemName = `${reductionInfo.name} - ${durationInfo.name}`;
+        const defaultPrice = this.calculateDefaultCooldownPrice(reductionInfo.percent, durationInfo.days);
+
+        const modal = new ModalBuilder()
+            .setCustomId(`cooldown_reduction_modal_${reduction}_${duration}`)
+            .setTitle('Ajouter Réduction de Cooldown')
+            .addComponents(
+                new ActionRowBuilder().addComponents(
+                    new TextInputBuilder()
+                        .setCustomId('cooldown_price')
+                        .setLabel('Prix (💋)')
+                        .setStyle(TextInputStyle.Short)
+                        .setPlaceholder(`Prix suggéré: ${defaultPrice}`)
+                        .setValue(defaultPrice.toString())
+                        .setRequired(true)
+                ),
+                new ActionRowBuilder().addComponents(
+                    new TextInputBuilder()
+                        .setCustomId('cooldown_description')
+                        .setLabel('Description personnalisée (optionnelle)')
+                        .setStyle(TextInputStyle.Paragraph)
+                        .setPlaceholder(`${itemName} - ${reductionInfo.percent === 100 ? 'Supprime' : 'Réduit de ' + reductionInfo.percent + '%'} tous les cooldowns pendant ${durationInfo.name}`)
+                        .setRequired(false)
+                )
+            );
+
+        await interaction.showModal(modal);
+    }
+
+    calculateDefaultCooldownPrice(percent, days) {
+        // Prix de base selon le pourcentage de réduction
+        let basePrice = 100; // Prix pour 50%, 1 jour
+        
+        if (percent === 75) basePrice = 250;
+        else if (percent === 100) basePrice = 500;
+        
+        // Multiplicateur selon la durée
+        let multiplier = 1;
+        if (days === 7) multiplier = 5;
+        else if (days === 30) multiplier = 15;
+        
+        return basePrice * multiplier;
+    }
+
+    async handleCooldownReductionModal(interaction) {
+        try {
+            const customId = interaction.customId; // cooldown_reduction_modal_50_1d
+            const parts = customId.split('_');
+            const reduction = parts[3]; // "50", "75", or "100"
+            const duration = parts[4]; // "1d", "1w", or "1m"
+
+            const price = parseInt(interaction.fields.getTextInputValue('cooldown_price'));
+            const description = interaction.fields.getTextInputValue('cooldown_description');
+
+            if (isNaN(price) || price <= 0) {
+                await interaction.reply({
+                    content: '❌ Prix invalide. Doit être un nombre positif.',
+                    flags: 64
+                });
+                return;
+            }
+
+            // Mapper les valeurs
+            const reductionMap = {
+                '50': { name: '🔥 50% de réduction', percent: 50 },
+                '75': { name: '⚡ 75% de réduction', percent: 75 },
+                '100': { name: '🚀 Actions illimitées', percent: 100 }
+            };
+            
+            const durationMap = {
+                '1d': { name: '1 jour', days: 1 },
+                '1w': { name: '1 semaine', days: 7 },
+                '1m': { name: '1 mois', days: 30 }
+            };
+
+            const reductionInfo = reductionMap[reduction];
+            const durationInfo = durationMap[duration];
+            
+            const itemName = `${reductionInfo.name} - ${durationInfo.name}`;
+            const finalDescription = description || `${reductionInfo.percent === 100 ? 'Supprime' : 'Réduit de ' + reductionInfo.percent + '%'} tous les cooldowns pendant ${durationInfo.name}`;
+
+            // Sauvegarder l'article dans la boutique
+            await this.saveCooldownReductionToShop(
+                interaction.guild.id, 
+                itemName, 
+                price, 
+                finalDescription,
+                reductionInfo.percent,
+                durationInfo.days
+            );
+
+            await interaction.reply({
+                content: `✅ Article "${itemName}" ajouté à la boutique pour ${price}💋 !`,
+                flags: 64
+            });
+
+        } catch (error) {
+            console.error('Erreur modal réduction cooldown:', error);
+            await interaction.reply({
+                content: '❌ Erreur lors de la création de l\'article.',
+                flags: 64
+            });
+        }
+    }
+
+    async saveCooldownReductionToShop(guildId, name, price, description, reductionPercent, durationDays) {
+        const shopData = await this.dataManager.loadData('shop.json', {});
+        
+        if (!shopData[guildId]) shopData[guildId] = [];
+        
+        const cooldownItem = {
+            id: Date.now().toString(),
+            type: 'cooldown_reduction',
+            name: name,
+            price: price,
+            description: description,
+            category: 'Réductions de Cooldown',
+            reductionPercent: reductionPercent,
+            durationDays: durationDays,
+            created: new Date().toISOString()
+        };
+        
+        shopData[guildId].push(cooldownItem);
+        await this.dataManager.saveData('shop.json', shopData);
+        console.log(`✅ Réduction cooldown ajoutée à la boutique:`, cooldownItem);
     }
 
     async showRemisesMenu(interaction) {

--- a/handlers/MainRouterHandler.js
+++ b/handlers/MainRouterHandler.js
@@ -604,6 +604,17 @@ class MainRouterHandler {
                 return true;
             }
 
+            // === SELECT MENUS RÉDUCTIONS COOLDOWN ===
+            if (customId === 'economy_boutique_select') {
+                await this.economyHandler.handleBoutiqueSelect(interaction);
+                return true;
+            }
+
+            if (customId === 'cooldown_reduction_select') {
+                await this.economyHandler.handleCooldownReductionSelect(interaction);
+                return true;
+            }
+
             // === SELECT MENUS CONFESSION ===
             // Menus d'options principaux (logs / autothread / canaux)
             if (customId === 'confession_logs_options') {

--- a/index.render-final.js
+++ b/index.render-final.js
@@ -4670,6 +4670,23 @@ async function handleShopPurchase(interaction, dataManager) {
             inventoryItem.type = 'private_suite_permanent';
         }
 
+        // Gestion réductions de cooldown
+        if (item.type === 'cooldown_reduction') {
+            inventoryItem.reductionPercent = item.reductionPercent;
+            inventoryItem.durationDays = item.durationDays;
+            inventoryItem.expiresAt = new Date(Date.now() + (item.durationDays * 24 * 60 * 60 * 1000)).toISOString();
+            
+            // Ajouter aux buffs actifs de l'utilisateur
+            if (!userData.cooldownBuffs) userData.cooldownBuffs = [];
+            userData.cooldownBuffs.push({
+                id: inventoryItem.id,
+                reductionPercent: item.reductionPercent,
+                activatedAt: new Date().toISOString(),
+                expiresAt: inventoryItem.expiresAt,
+                name: item.name
+            });
+        }
+
         userData.inventory.push(inventoryItem);
         await dataManager.updateUser(userId, guildId, userData);
 
@@ -4710,6 +4727,12 @@ async function handleShopPurchase(interaction, dataManager) {
             }
         } else if (item.type === 'private_24h' || item.type === 'private_monthly' || item.type === 'private_permanent') {
             effectMessage = '\n🔒 Suite privée créée: 1 rôle + 2 salons (🔞 texte NSFW + 🎙️ vocal)';
+        } else if (item.type === 'cooldown_reduction') {
+            if (item.reductionPercent === 100) {
+                effectMessage = `\n🚀 **Actions illimitées activées !** Aucun cooldown pendant ${item.durationDays} jour${item.durationDays > 1 ? 's' : ''} !`;
+            } else {
+                effectMessage = `\n⚡ **Réduction de cooldown activée !** -${item.reductionPercent}% sur toutes les actions pendant ${item.durationDays} jour${item.durationDays > 1 ? 's' : ''} !`;
+            }
         } else if (item.type === 'custom_object' || item.type === 'custom' || item.type === 'text') {
             effectMessage = '\n🎁 Objet personnalisé acheté !';
         } else {

--- a/utils/cooldownCalculator.js
+++ b/utils/cooldownCalculator.js
@@ -1,0 +1,118 @@
+/**
+ * Utilitaire pour calculer les cooldowns avec réductions actives
+ */
+
+/**
+ * Calculer le cooldown final avec les buffs actifs de l'utilisateur
+ * @param {Object} userData - Données de l'utilisateur
+ * @param {number} baseCooldown - Cooldown de base en millisecondes
+ * @returns {number} Cooldown final en millisecondes
+ */
+function calculateReducedCooldown(userData, baseCooldown) {
+    // Nettoyer les buffs expirés d'abord
+    const now = Date.now();
+    if (userData.cooldownBuffs) {
+        userData.cooldownBuffs = userData.cooldownBuffs.filter(buff => {
+            const expiresAt = new Date(buff.expiresAt).getTime();
+            return expiresAt > now;
+        });
+    }
+
+    // Si pas de buffs actifs, retourner le cooldown de base
+    if (!userData.cooldownBuffs || userData.cooldownBuffs.length === 0) {
+        return baseCooldown;
+    }
+
+    // Trouver la meilleure réduction active (la plus élevée)
+    const bestReduction = Math.max(...userData.cooldownBuffs.map(buff => buff.reductionPercent || 0));
+
+    // Si réduction de 100%, pas de cooldown
+    if (bestReduction >= 100) {
+        return 0;
+    }
+
+    // Appliquer la réduction
+    const reducedCooldown = Math.floor(baseCooldown * (100 - bestReduction) / 100);
+    return Math.max(0, reducedCooldown);
+}
+
+/**
+ * Obtenir des informations sur les buffs actifs pour affichage
+ * @param {Object} userData - Données de l'utilisateur
+ * @returns {Object} Informations sur les buffs actifs
+ */
+function getActiveCooldownBuffs(userData) {
+    const now = Date.now();
+    
+    // Nettoyer les buffs expirés
+    if (userData.cooldownBuffs) {
+        userData.cooldownBuffs = userData.cooldownBuffs.filter(buff => {
+            const expiresAt = new Date(buff.expiresAt).getTime();
+            return expiresAt > now;
+        });
+    }
+
+    if (!userData.cooldownBuffs || userData.cooldownBuffs.length === 0) {
+        return {
+            hasActiveBuffs: false,
+            bestReduction: 0,
+            activeBuffs: []
+        };
+    }
+
+    const bestReduction = Math.max(...userData.cooldownBuffs.map(buff => buff.reductionPercent || 0));
+    
+    return {
+        hasActiveBuffs: true,
+        bestReduction,
+        activeBuffs: userData.cooldownBuffs,
+        isUnlimited: bestReduction >= 100
+    };
+}
+
+/**
+ * Formatter un message sur les buffs actifs pour l'affichage
+ * @param {Object} userData - Données de l'utilisateur
+ * @returns {string} Message formaté ou chaîne vide
+ */
+function formatCooldownBuffMessage(userData) {
+    const buffInfo = getActiveCooldownBuffs(userData);
+    
+    if (!buffInfo.hasActiveBuffs) {
+        return '';
+    }
+
+    if (buffInfo.isUnlimited) {
+        return '\n🚀 **Actions illimitées actives !** Aucun cooldown !';
+    }
+
+    return `\n⚡ **Réduction de cooldown active !** -${buffInfo.bestReduction}% sur toutes les actions !`;
+}
+
+/**
+ * Nettoyer les buffs expirés des données utilisateur
+ * @param {Object} userData - Données de l'utilisateur à nettoyer
+ * @returns {boolean} True si des buffs ont été supprimés
+ */
+function cleanExpiredBuffs(userData) {
+    if (!userData.cooldownBuffs || userData.cooldownBuffs.length === 0) {
+        return false;
+    }
+
+    const now = Date.now();
+    const initialLength = userData.cooldownBuffs.length;
+    
+    userData.cooldownBuffs = userData.cooldownBuffs.filter(buff => {
+        const expiresAt = new Date(buff.expiresAt).getTime();
+        return expiresAt > now;
+    });
+
+    return userData.cooldownBuffs.length < initialLength;
+}
+
+module.exports = {
+    calculateReducedCooldown,
+    getActiveCooldownBuffs,
+    formatCooldownBuffMessage,
+    cleanExpiredBuffs
+};


### PR DESCRIPTION
Ajoute une nouvelle catégorie "Réductions de Cooldown" à la boutique, permettant aux utilisateurs d'acheter des buffs temporaires qui réduisent ou suppriment les délais des actions du serveur.

Cette fonctionnalité enrichit le système économique en offrant de nouvelles options d'achat et permet aux joueurs d'accélérer leurs activités, rendant le gameplay plus dynamique.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0bafd8d-3572-408d-9229-5241a3ef3e87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0bafd8d-3572-408d-9229-5241a3ef3e87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

