### PR TITLE
Vérifier la réduction du cooldown de la boutique

### DIFF
--- a/commands/boutique.js
+++ b/commands/boutique.js
@@ -10,6 +10,13 @@ module.exports = {
 		try {
 			const guildId = interaction.guild.id;
 			const userId = interaction.user.id;
+			// Auto-générer les articles essentiels (suites privées + réductions de cooldown)
+			try {
+				const { ensurePrivateSuiteShopItems } = require('../utils/privateSuiteManager');
+				const { ensureCooldownReductionShopItems } = require('../utils/cooldownBoostManager');
+				await ensurePrivateSuiteShopItems(interaction.guild);
+				await ensureCooldownReductionShopItems(interaction.guild);
+			} catch (_) {}
 			
 			const userData = await dataManager.getUser(userId, guildId);
 			const shopData = await dataManager.loadData('shop.json', {});

--- a/index.production.js
+++ b/index.production.js
@@ -208,12 +208,14 @@ class ProductionBot {
             console.log(`✅ ${this.client.user.tag} connecté`);
             console.log(`🏰 ${this.client.guilds.cache.size} serveur(s) connecté(s)`);
             
-            // Suites privées (production léger): scan existant
+            // Suites privées (production léger): scan existant + items boutique
             try {
                 const { scanAndRepairSuites, ensurePrivateSuiteShopItems } = require('./utils/privateSuiteManager');
+                const { ensureCooldownReductionShopItems } = require('./utils/cooldownBoostManager');
                 await scanAndRepairSuites(this.client);
                 for (const guild of this.client.guilds.cache.values()) {
                     await ensurePrivateSuiteShopItems(guild);
+                    try { await ensureCooldownReductionShopItems(guild); } catch (_) {}
                 }
                 console.log('🔒 Suites privées prêtes (production)');
             } catch (e) {


### PR DESCRIPTION
Add auto-generation of cooldown reduction and private suite shop items to ensure they appear in the shop and are generated on production startup.

The shop was empty because `ensureCooldownReductionShopItems` was only called in a specific development mode and not in production. Additionally, the `/boutique` command did not attempt to ensure these items existed before displaying the shop. This PR ensures that these essential shop items are always available, both on bot startup in production and when a user opens the shop.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4cfc36b-b4fa-4288-b28f-12258dd5c1d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4cfc36b-b4fa-4288-b28f-12258dd5c1d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

